### PR TITLE
Added support for Ooyala video player

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,12 +1,12 @@
 # Octopress responsive video embed
 
-Helps you embed Youtube and Vimeo videos responsively to your Octopress since 2012. Also supports embeds from TrailerAddict.
+Helps you embed Youtube and Vimeo videos responsively to your Octopress since 2012. Also supports embeds from TrailerAddict and Ooyala (video player used by The Verge and Polygon).
 
 ## How to use it?
 
 There are 3 easy steps.
 
-1. Add ```youtube.rb```, ```vimeo.rb```, ```traileraddict.rb``` to your ```plugin``` folder.
+1. Add ```youtube.rb```, ```vimeo.rb```, ```traileraddict.rb```, ```ooyala.rb``` to your ```plugin``` folder.
 2. Copy the content from ```rve-styles.css``` to your own stylesheet or just add it to your template. (or to keep everything in sass, see below)
 3. Now you can easily embed videos using only the ```id``` like this:
 
@@ -22,6 +22,10 @@ There are 3 easy steps.
 # TrailerAddict example
 
 {% traileraddict 66840 %}
+
+# Ooyala example (needs two id's, ```pbid``` and ```ec```(
+
+{% ooyala 2ff6d6fff2b2457bb9ea2cfcf77dc25b 1xaW1nYTqi1Z1ZiLwcJ2qSSrg94NAtkQ %}
 
 ```
 

--- a/README.markdown
+++ b/README.markdown
@@ -23,7 +23,7 @@ There are 3 easy steps.
 
 {% traileraddict 66840 %}
 
-# Ooyala example (needs two id's, ```pbid``` and ```ec```(
+# Ooyala example (needs two id's, pbid and ec)
 
 {% ooyala 2ff6d6fff2b2457bb9ea2cfcf77dc25b 1xaW1nYTqi1Z1ZiLwcJ2qSSrg94NAtkQ %}
 

--- a/_rve.scss
+++ b/_rve.scss
@@ -4,6 +4,7 @@
   padding-top: 30px; /* IE6 workaround*/
   height: 0;
   overflow: hidden;
+  margin-bottom: 1.5em;
 
   iframe, object, embed {
     position: absolute;

--- a/ooyala.rb
+++ b/ooyala.rb
@@ -1,0 +1,17 @@
+module Jekyll
+  class Ooyala < Liquid::Tag
+
+    def initialize(name, params, tokens)
+      super
+      ids = params.split(' ')
+      @pbid = ids[0]
+      @ec = ids[1]
+    end
+
+    def render(context)
+      %(<div class="embed-video-container"><script src="http://player.ooyala.com/iframe.js#pbid=#{@pbid}&ec=#{@ec}"></script></div>)
+    end
+  end
+end
+
+Liquid::Template.register_tag('ooyala', Jekyll::Ooyala)


### PR DESCRIPTION
Added support for the Ooyala video player used by The Verge and Polygon. Please thoroughly review my code before pulling as I'm not a Ruby programmer (although none of this code appears to be rocket science ;-)).
