### PR TITLE
Remove protocol from the URLs to allow SSL and non-SSL sites

### DIFF
--- a/dailymotion.rb
+++ b/dailymotion.rb
@@ -5,7 +5,7 @@ module Jekyll
       @id = id
     end
     def render(context)
-	%(<div class="embed-video-container"><iframe src="http://www.dailymotion.com/embed/video/#{@id}"></iframe></div>)
+	%(<div class="embed-video-container"><iframe src="//www.dailymotion.com/embed/video/#{@id}"></iframe></div>)
     end
   end
 end

--- a/ooyala.rb
+++ b/ooyala.rb
@@ -9,7 +9,7 @@ module Jekyll
     end
 
     def render(context)
-      %(<div class="embed-video-container"><script src="http://player.ooyala.com/iframe.js#pbid=#{@pbid}&ec=#{@ec}"></script></div>)
+      %(<div class="embed-video-container"><script src="//player.ooyala.com/iframe.js#pbid=#{@pbid}&ec=#{@ec}"></script></div>)
     end
   end
 end

--- a/traileraddict.rb
+++ b/traileraddict.rb
@@ -7,7 +7,7 @@ module Jekyll
     end
 
     def render(context)
-      %(<div class="embed-video-container"><iframe src="http://www.traileraddict.com/emd/#{@id}"></iframe></div>)
+      %(<div class="embed-video-container"><iframe src="//www.traileraddict.com/emd/#{@id}"></iframe></div>)
     end
   end
 end

--- a/vimeo.rb
+++ b/vimeo.rb
@@ -7,7 +7,7 @@ module Jekyll
     end
 
     def render(context)
-      %(<div class="embed-video-container"><iframe src="http://player.vimeo.com/video/#{@id}"></iframe></div>)
+      %(<div class="embed-video-container"><iframe src="//player.vimeo.com/video/#{@id}"></iframe></div>)
     end
   end
 end

--- a/youtube.rb
+++ b/youtube.rb
@@ -7,7 +7,7 @@ module Jekyll
     end
 
     def render(context)
-      %(<div class="embed-video-container"><iframe src="http://www.youtube.com/embed/#{@id.strip}" allowfullscreen></iframe></div>)
+      %(<div class="embed-video-container"><iframe src="//www.youtube.com/embed/#{@id.strip}" allowfullscreen></iframe></div>)
     end
   end
 end


### PR DESCRIPTION
Hi!

I remove the protocol from the URL's to allow the SSL sites too...
If not, the plugin don't work on sites under SSL because it's trying to load "unsecure" content...

With this little modification, the plugin works fine in both sites (http and https sites)
